### PR TITLE
feat(chore): add the command structure for the bot

### DIFF
--- a/src/main/kotlin/com/vit123long/Application.kt
+++ b/src/main/kotlin/com/vit123long/Application.kt
@@ -1,5 +1,7 @@
 package com.vit123long
 
+import com.vit123long.models.GithubBot
+import com.vit123long.models.enum.CommandAvailable
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import com.vit123long.plugins.*
@@ -7,5 +9,11 @@ import com.vit123long.plugins.*
 fun main() {
     embeddedServer(Netty, port = 8080, host = "0.0.0.0") {
         configureRouting()
+        exampleInitCommand()
     }.start(wait = true)
+}
+
+fun exampleInitCommand(){
+    val bot = GithubBot()
+    bot.setupPublishCommand()
 }

--- a/src/main/kotlin/com/vit123long/models/GithubBot.kt
+++ b/src/main/kotlin/com/vit123long/models/GithubBot.kt
@@ -1,0 +1,23 @@
+package com.vit123long.models
+
+class GithubBot() {
+
+    //Init the command ONLY when is ready to be used
+    private val publishCommand: PublishCommand by lazy {
+        initPublishCommand()
+    }
+
+    //Init the command ONLY when is ready to be used
+    private val pingCommand: PingCommand by lazy {
+        initPingCommand()
+    }
+
+    private fun initPublishCommand(): PublishCommand = PublishCommand()
+
+    private fun initPingCommand(): PingCommand = PingCommand()
+
+    fun setupPublishCommand(){
+        publishCommand.config()
+        publishCommand.run()
+    }
+}

--- a/src/main/kotlin/com/vit123long/models/PingCommand.kt
+++ b/src/main/kotlin/com/vit123long/models/PingCommand.kt
@@ -1,0 +1,16 @@
+package com.vit123long.models
+
+import com.vit123long.models.enum.CommandAvailable
+import com.vit123long.models.interfaces.ICommand
+
+class PingCommand: ICommand {
+
+    override fun config() {
+        TODO("Not yet implemented")
+    }
+
+    override fun run():Boolean {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/src/main/kotlin/com/vit123long/models/PublishCommand.kt
+++ b/src/main/kotlin/com/vit123long/models/PublishCommand.kt
@@ -1,0 +1,21 @@
+package com.vit123long.models
+
+import com.vit123long.models.enum.CommandAvailable
+import com.vit123long.models.interfaces.ICommand
+
+/**
+ * Publish the result to the client
+ * */
+class PublishCommand() : ICommand {
+
+    override fun config() {
+        TODO("Not yet implemented")
+    }
+
+    override fun run(): Boolean {
+        println("Publish command success")
+        return true
+    }
+
+
+}

--- a/src/main/kotlin/com/vit123long/models/enum/CommandAvailable.kt
+++ b/src/main/kotlin/com/vit123long/models/enum/CommandAvailable.kt
@@ -1,0 +1,7 @@
+package com.vit123long.models.enum
+
+enum class CommandAvailable {
+    PING,
+    PUBLISH,
+    PRINT
+}

--- a/src/main/kotlin/com/vit123long/models/interfaces/ICommand.kt
+++ b/src/main/kotlin/com/vit123long/models/interfaces/ICommand.kt
@@ -1,0 +1,15 @@
+package com.vit123long.models.interfaces
+
+import com.vit123long.models.enum.CommandAvailable
+
+interface ICommand {
+    /**
+     * Configure the specific command
+     */
+    fun config()
+    /**
+     * Run the specific command
+     * return True if it was successful or False otherwise
+     */
+    fun run(): Boolean
+}


### PR DESCRIPTION
Add the command structure for the bot. This is just the initial config.
The following diagram explains the structure:

<img width="447" alt="Screen Shot 2022-04-17 at 5 43 31 PM" src="https://user-images.githubusercontent.com/49449095/163734999-1ee0c037-368b-4787-94dd-b648a4877566.png">